### PR TITLE
Improve handling of hdRatio, hitsSurvived, and voidMaps

### DIFF
--- a/modules/breedtimer.js
+++ b/modules/breedtimer.js
@@ -5,10 +5,10 @@ var DecimalBreed = Decimal.clone({precision: 30, rounding: 4});
 var missingTrimps = new DecimalBreed(0);
 
 //Lowers breed timer proportionally to the amount of Momentum during Lead
-function customLeadTimer() {
+function customLeadTimer(hdStats) {
     //If instakilling, timer = 30
     var formation = game.upgrades.Dominance.done ? "D" : "X";
-    if (oneShotZone(formation)) return 30;
+    if (oneShotZone(game.global.world, hdStats.targetZoneType, formation)) return 30;
 
     //Timer = 10 to 30, according to the number of stacks. Or from 5-30 if Scrying
     if (game.global.formation != 4) return Math.min(30, 35 - game.challenges.Lead.stacks/8.0);
@@ -104,7 +104,7 @@ function breedTimeRemaining() {
     return DecimalBreed.log10(maxBreedable.div(breeding)).div(DecimalBreed.log10(potencyMod())).div(10);
 }
 
-function ATGA2() {
+function ATGA2(hdStats) {
 	if (game.jobs.Geneticist.locked == false && getPageSetting('ATGA2') == true && getPageSetting('ATGA2timer') > 0 && game.global.challengeActive != "Trapper"){
 		//Init
         var timeRemaining = breedTimeRemaining();
@@ -141,7 +141,7 @@ function ATGA2() {
 			target = new Decimal(Math.ceil(isNaN(atl) ? target : atl/1000*(((game.portal.Agility.level) ? 1000 * Math.pow(1 - game.portal.Agility.modifier, game.portal.Agility.level) : 1000) + ((game.talents.hyperspeed2.purchased && (game.global.world <= Math.floor((game.global.highestLevelCleared + 1) * 0.5))) || (game.global.mapExtraBonus == "fa")) * -100 + (game.talents.hyperspeed.purchased) * -100)));
 		}
 		
-		if (game.global.challengeActive == 'Lead') target = new Decimal(customLeadTimer());
+		if (game.global.challengeActive == 'Lead') target = new Decimal(customLeadTimer(hdStats));
 
 		var now = new Date().getTime();
 		var thresh = new DecimalBreed(totalTime.mul(0.02));

--- a/modules/calc.js
+++ b/modules/calc.js
@@ -5,12 +5,12 @@ var trimpAA = 1;
 //Helium
 
 class HDStats {
-    hdRatio;
-    hitsSurvived;
-    ourDamage;
-    targetZoneType;
-
     constructor(vmStatus) {
+        this.hdRatio = undefined;
+        this.hitsSurvived = undefined;
+        this.ourDamage = undefined;
+        this.targetZoneType = undefined;
+
         const z = game.global.world;
 
         this.targetZoneType = (vmStatus.prepareForVoids ? "void" : "world");

--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -203,12 +203,12 @@ var Best;
 function orangewindstack(){(9<game.equipment.Dagger.level&&0==game.upgrades.Dagadder.locked&&buyUpgrade('Dagadder',!0,!0),9<game.equipment.Mace.level&&0==game.upgrades.Megamace.locked&&buyUpgrade('Megamace',!0,!0),9<game.equipment.Polearm.level&&0==game.upgrades.Polierarm.locked&&buyUpgrade('Polierarm',!0,!0),9<game.equipment.Battleaxe.level&&0==game.upgrades.Axeidic.locked&&buyUpgrade('Axeidic',!0,!0),9<game.equipment.Greatsword.level&&0==game.upgrades.Greatersword.locked&&buyUpgrade('Greatersword',!0,!0),9<game.equipment.Arbalest.level&&0==game.upgrades.Harmbalest.locked&&buyUpgrade('Harmbalest',!0,!0),0==game.upgrades.Bootboost.locked&&buyUpgrade('Bootboost',!0,!0),0==game.upgrades.Hellishmet.locked&&buyUpgrade('Hellishmet',!0,!0),0==game.upgrades.Pantastic.locked&&buyUpgrade('Pantastic',!0,!0),0==game.upgrades.Smoldershoulder.locked&&buyUpgrade('Smoldershoulder',!0,!0),0==game.upgrades.Bestplate.locked&&buyUpgrade('Bestplate',!0,!0),0==game.upgrades.GambesOP.locked&&buyUpgrade('GambesOP',!0,!0),0==game.upgrades.Supershield.locked&&buyUpgrade('Supershield',!0,!0))}
 function dorangewindstack(){(9<game.equipment.Dagger.level&&0==game.upgrades.Dagadder.locked&&buyUpgrade('Dagadder',!0,!0),9<game.equipment.Mace.level&&0==game.upgrades.Megamace.locked&&buyUpgrade('Megamace',!0,!0),9<game.equipment.Polearm.level&&0==game.upgrades.Polierarm.locked&&buyUpgrade('Polierarm',!0,!0),9<game.equipment.Battleaxe.level&&0==game.upgrades.Axeidic.locked&&buyUpgrade('Axeidic',!0,!0),9<game.equipment.Greatsword.level&&0==game.upgrades.Greatersword.locked&&buyUpgrade('Greatersword',!0,!0),9<game.equipment.Arbalest.level&&0==game.upgrades.Harmbalest.locked&&buyUpgrade('Harmbalest',!0,!0),0==game.upgrades.Bootboost.locked&&buyUpgrade('Bootboost',!0,!0),0==game.upgrades.Hellishmet.locked&&buyUpgrade('Hellishmet',!0,!0),0==game.upgrades.Pantastic.locked&&buyUpgrade('Pantastic',!0,!0),0==game.upgrades.Smoldershoulder.locked&&buyUpgrade('Smoldershoulder',!0,!0),0==game.upgrades.Bestplate.locked&&buyUpgrade('Bestplate',!0,!0),0==game.upgrades.GambesOP.locked&&buyUpgrade('GambesOP',!0,!0),0==game.upgrades.Supershield.locked&&buyUpgrade('Supershield',!0,!0))}
 
-function windstackingprestige() {
+function windstackingprestige(hdStats) {
     if (
-		(game.global.challengeActive != "Daily" && getEmpowerment() == "Wind" && getPageSetting('WindStackingMin') > 0 && game.global.world >= getPageSetting('WindStackingMin') && calcHDRatio() < 5) ||
-		(game.global.challengeActive == "Daily" && getEmpowerment() == "Wind" && getPageSetting('dWindStackingMin') > 0 && game.global.world >= getPageSetting('dWindStackingMin') && calcHDRatio() < 5) ||
-		(game.global.challengeActive != "Daily" && getPageSetting('wsmax') > 0 && getPageSetting('wsmaxhd') > 0 && game.global.world >= getPageSetting('wsmax') && calcHDRatio() < getPageSetting('wsmaxhd')) ||
-		(game.global.challengeActive == "Daily" && getPageSetting('dwsmax') > 0 && getPageSetting('dwsmaxhd') > 0 && game.global.world >= getPageSetting('dwsmax') && calcHDRatio() < getPageSetting('dwsmaxhd'))
+		(game.global.challengeActive != "Daily" && getEmpowerment() == "Wind" && getPageSetting('WindStackingMin') > 0 && game.global.world >= getPageSetting('WindStackingMin') && hdStats.hdRatio < 5) ||
+		(game.global.challengeActive == "Daily" && getEmpowerment() == "Wind" && getPageSetting('dWindStackingMin') > 0 && game.global.world >= getPageSetting('dWindStackingMin') && hdStats.hdRatio < 5) ||
+		(game.global.challengeActive != "Daily" && getPageSetting('wsmax') > 0 && getPageSetting('wsmaxhd') > 0 && game.global.world >= getPageSetting('wsmax') && hdStats.hdRatio < getPageSetting('wsmaxhd')) ||
+		(game.global.challengeActive == "Daily" && getPageSetting('dwsmax') > 0 && getPageSetting('dwsmaxhd') > 0 && game.global.world >= getPageSetting('dwsmax') && hdStats.hdRatio < getPageSetting('dwsmaxhd'))
 	) {
 	if (game.global.challengeActive != "Daily") orangewindstack();
 	if (game.global.challengeActive == "Daily") dorangewindstack();
@@ -278,7 +278,7 @@ function weaponCapped() {
     return capped && prestigeItemsLeft == 0 && numUnbought == 0;
 }
 
-function autoLevelEquipment() {
+function autoLevelEquipment(hdStats, vmStatus) {
     var gearamounttobuy = (getPageSetting('gearamounttobuy') > 0) ? getPageSetting('gearamounttobuy') : 1;
 
     //WS
@@ -310,8 +310,8 @@ function autoLevelEquipment() {
 
     //Check for H & D
     var formation = (game.global.world < 60 || game.global.highestLevelCleared < 180) ? "X" : "S";
-    var enoughDamageE = enoughDamage && oneShotZone(formation) >= 1;
-    var enoughHealthE = calcHealthRatio() > getMapHealthCutOff() * MODULES.equipment.numHitsMult;
+    var enoughDamageE = enoughDamage && oneShotZone(game.global.world, hdStats.targetZoneType, formation) >= 1;
+    var enoughHealthE = hdStats.hitsSurvived > getMapHealthCutOff(vmStatus) * MODULES.equipment.numHitsMult;
 
     //Check mirror dailies
     var mirroredDaily = game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.mirrored !== "undefined";
@@ -354,7 +354,7 @@ function autoLevelEquipment() {
                 }
             }
 
-            if (evaluation.StatusBorder == 'red' && windstackingprestige() && !(game.global.world < 60 && game.global.world >= 58 && MODULES["equipment"].waitTill60)) {
+            if (evaluation.StatusBorder == 'red' && windstackingprestige(hdStats) && !(game.global.world < 60 && game.global.world >= 58 && MODULES["equipment"].waitTill60)) {
                 var BuyWeaponUpgrades = ((getPageSetting('BuyWeaponsNew') == 1) || (getPageSetting('BuyWeaponsNew') == 2));
                 var BuyArmorUpgrades = ((getPageSetting('BuyArmorNew') == 1) || (getPageSetting('BuyArmorNew') == 2));
                 var DelayArmorWhenNeeded = getPageSetting('DelayArmorWhenNeeded');
@@ -414,7 +414,7 @@ function autoLevelEquipment() {
                     buyEquipment(eqName, null, true);
                 }
             }
-            if (windstackingprestige() && BuyWeaponLevels && DaThing.Stat == 'attack' && mirroredDailyOk && (!enoughDamageE || enoughHealthE || maxmap)) {
+            if (windstackingprestige(hdStats) && BuyWeaponLevels && DaThing.Stat == 'attack' && mirroredDailyOk && (!enoughDamageE || enoughHealthE || maxmap)) {
                 game.global.buyAmt = gearamounttobuy;
                 if (DaThing.Equip && !Best[stat].Wall && canAffordBuilding(eqName, null, null, true)) {
                     debug('Leveling equipment ' + eqName, "equips", '*upload3');

--- a/modules/other.js
+++ b/modules/other.js
@@ -1849,9 +1849,9 @@ function fightalways() {
 	    fightManual();
 }
 
-function armormagic() {
+function armormagic(hdStats) {
 	var armormagicworld =  Math.floor((game.global.highestLevelCleared + 1) * 0.8);
-	if (((getPageSetting('carmormagic') == 1 || getPageSetting('darmormagic') == 1) && game.global.world >= armormagicworld && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)) || ((getPageSetting('carmormagic') == 2 || getPageSetting('darmormagic') == 2) && calcHDRatio() >= MODULES["maps"].enoughDamageCutoff && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)) || ((getPageSetting('carmormagic') == 3 || getPageSetting('darmormagic') == 3) && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)))
+	if (((getPageSetting('carmormagic') == 1 || getPageSetting('darmormagic') == 1) && game.global.world >= armormagicworld && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)) || ((getPageSetting('carmormagic') == 2 || getPageSetting('darmormagic') == 2) && hdStats.hdRatio >= MODULES["maps"].enoughDamageCutoff && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)) || ((getPageSetting('carmormagic') == 3 || getPageSetting('darmormagic') == 3) && (game.global.soldierHealth <= game.global.soldierHealthMax*0.4)))
 	 buyArms();
 }
 

--- a/modules/performance.js
+++ b/modules/performance.js
@@ -141,10 +141,12 @@
 
 	M["performance"].UpdateAFKOverlay = function UpdateAFKOverlay()
 	{
+        const vmStatus = getVoidMapStatus();
+        const hdStats = new HDStats(vmStatus);
 		M["performance"].AFKOverlayZone.innerText = 'Current Zone: ' + game.global.world;
 		if (game.global.universe == 1) {
 		    M["performance"].AFKOverlayHelium.innerText = 'Current Helium: ' + prettify(Math.floor(game.resources.helium.owned));
-		    M["performance"].AFKOverlayStatus.innerHTML = 'Current Status: ' + updateAutoMapsStatus(true)[0];
+		    M["performance"].AFKOverlayStatus.innerHTML = 'Current Status: ' + updateAutoMapsStatus(true, hdStats, vmStatus)[0];
 		}
 		if (game.global.universe == 2) {
 		    M["performance"].AFKOverlayHelium.innerText = 'Current Radon: ' + prettify(Math.floor(game.resources.radon.owned));

--- a/modules/scryer.js
+++ b/modules/scryer.js
@@ -28,11 +28,11 @@ function readyToSwitch(stance = "S") {
     return die || survive(stance, 2);
 }
 
-function useScryerStance() {
+function useScryerStance(hdStats) {
     var scry = 4;
     var scryF = 'S';
     var x = 0;
-    
+
     if (game.global.uberNature == "Wind" && getEmpowerment() != "Wind") {
         scry = 5;
         scryF = 'W';
@@ -41,7 +41,7 @@ function useScryerStance() {
     
     var AutoStance = getPageSetting('AutoStance');
     function autoStanceFunctionScryer() {
-        if ((getPageSetting('AutoStance') == 3) || (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily")) windStance();
+        if ((getPageSetting('AutoStance') == 3) || (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily")) windStance(hdStats);
         else if (AutoStance==1) autoStance();
         else if (AutoStance==2) autoStance2();
     }
@@ -69,7 +69,7 @@ function useScryerStance() {
         never_scry |= !scryNext;
     }
     else transitionRequired = false;
-    
+
     //check Healthy never -- TODO
     var curEnemyHealth = getCurrentEnemy(1);
     var isHealthy = curEnemyHealth && curEnemyHealth.mutation == "Healthy";
@@ -116,7 +116,7 @@ function useScryerStance() {
 
     //Overkill
     if (useOverkill && getCurrentEnemy()) {
-        //Switches to S if it has enough damage to secure an overkill
+        //Switches to S/W if it has enough damage to secure an overkill
         var HS = oneShotPower(scryF);
         var HSD = oneShotPower("D", 0, true);
         var HS_next = oneShotPower(scryF, 1);
@@ -139,7 +139,7 @@ function useScryerStance() {
     var max_zone = getPageSetting('ScryerMaxZone');
     var valid_min = game.global.world >= min_zone && game.global.world > 60;
     var valid_max = max_zone <= 0 || game.global.world < max_zone;
-    
+
     if (USS && valid_min && valid_max && (!MA || getPageSetting('onlyminmaxworld') == 0) && readyToSwitch()) {
         //Smooth transition to S before killing the target
         if (transitionRequired) {
@@ -152,7 +152,7 @@ function useScryerStance() {
             }
         }
 
-        //Set to scry if it won't kill us or we are willing to die for it
+        //Set to scry if it won't kill us, or we are willing to die for it
         setFormation(scry);
         wantToScry = true;
         return;

--- a/modules/stance.js
+++ b/modules/stance.js
@@ -56,11 +56,7 @@ function maxOneShotPower(considerEdges) {
     return power;
 }
 
-function oneShotZone(specificStance, type, zone, maxOrMin) {
-    //Pre-Init
-    if (!type) type = preVoidCheck ? "void" : "world";
-    if (!zone) zone = game.global.world;
-
+function oneShotZone(zone, type, specificStance, maxOrMin) {
     //Calculates our minimum damage
     var baseDamage = calcOurDmg(maxOrMin ? "max" : "min", specificStance, true, type != "world");
     var damageLeft = baseDamage + addPoison(false, (type == "world") ? zone : game.global.world);
@@ -291,77 +287,78 @@ function autoStance2() {
                setFormation(2);
 }
 
-function windStance() {
+function windStance(hdStats) {
     //Fail safes
     if (game.global.gridArray.length === 0) return;
     if (game.global.soldierHealth <= 0) return;
     if (!game.upgrades.Formations.done) return;
     if (game.global.world <= 70) return;
     var stancey = 2;
-    if (game.global.challengeActive != "Daily") {
-	if (calcCurrentStance() == 5) {
+    const currentStance = calcCurrentStance(hdStats);
+    if (game.global.challengeActive !== "Daily") {
+	if (currentStance === 5) {
             stancey = 5;
             lowHeirloom();
         }
-        if (calcCurrentStance() == 2) {
+        if (currentStance === 2) {
             stancey = 2;
             lowHeirloom();
         }
-        if (calcCurrentStance() == 0) {
+        if (currentStance === 0) {
             stancey = 0;
             lowHeirloom();
         }
-        if (calcCurrentStance() == 1) {
+        if (currentStance === 1) {
             stancey = 1;
             lowHeirloom();
         }
-        if (calcCurrentStance() == 15) {
+        if (currentStance === 15) {
             stancey = 5;
             highHeirloom();
         }
-        if (calcCurrentStance() == 12) {
+        if (currentStance === 12) {
             stancey = 2;
             highHeirloom();
         }
-        if (calcCurrentStance() == 10) {
+        if (currentStance === 10) {
             stancey = 0;
             highHeirloom();
         }
-        if (calcCurrentStance() == 11) {
+        if (currentStance === 11) {
             stancey = 1;
             highHeirloom();
         }
     }
-    if (game.global.challengeActive == "Daily") {
-	if (calcCurrentStance() == 5) {
+    if (game.global.challengeActive === "Daily") {
+	if (currentStance === 5) {
             stancey = 5;
             dlowHeirloom();
         }
-        if (calcCurrentStance() == 2) {
+        if (currentStance === 2) {
             stancey = 2;
             dlowHeirloom();
         }
-        if (calcCurrentStance() == 0) {
+        if (currentStance === 0) {
             stancey = 0;
             dlowHeirloom();
         }
-        if (calcCurrentStance() == 1) {
+        if (currentStance === 1) {
             stancey = 1;
             dlowHeirloom();
         }
-        if (calcCurrentStance() == 15) {
+        if (currentStance === 15) {
             stancey = 5;
             dhighHeirloom();
         }
-        if (calcCurrentStance() == 12) {
+        if (currentStance === 12) {
             stancey = 2;
             dhighHeirloom();
         }
-        if (calcCurrentStance() == 10) {
+        if (currentStance === 10) {
             stancey = 0;
             dhighHeirloom();
         }
-        if (calcCurrentStance() == 11) {
+        if (currentStance === 11) {
             stancey = 1;
             dhighHeirloom();
         }

--- a/modules/upgrades.js
+++ b/modules/upgrades.js
@@ -113,7 +113,7 @@ function needGymystic() {
     return game.upgrades['Gymystic'].allowed - game.upgrades['Gymystic'].done > 0;
 }
 
-function buyUpgrades() {
+function buyUpgrades(hdStats) {
     //For every upgrade available...
     for (var upgrade in upgradeList) {
         upgrade = upgradeList[upgrade];
@@ -126,17 +126,17 @@ function buyUpgrades() {
         
         //Coord & Amals
         if (upgrade == 'Coordination' && (getPageSetting('BuyUpgradesNew') == 2 || !canAffordCoordinationTrimps())) continue;
-        if (upgrade == 'Coordination' && getPageSetting('amalcoord')==true && getPageSetting('amalcoordhd') > 0 && calcHDRatio() < getPageSetting('amalcoordhd') && ((getPageSetting('amalcoordt') < 0 && (game.global.world < getPageSetting('amalcoordz') || getPageSetting('amalcoordz') < 0)) || (getPageSetting('amalcoordt') > 0 && getPageSetting('amalcoordt') > game.jobs.Amalgamator.owned && (game.resources.trimps.realMax() / game.resources.trimps.getCurrentSend()) > 2000))) continue;
+        if (upgrade == 'Coordination' && getPageSetting('amalcoord')==true && getPageSetting('amalcoordhd') > 0 && hdStats.hdRatio < getPageSetting('amalcoordhd') && ((getPageSetting('amalcoordt') < 0 && (game.global.world < getPageSetting('amalcoordz') || getPageSetting('amalcoordz') < 0)) || (getPageSetting('amalcoordt') > 0 && getPageSetting('amalcoordt') > game.jobs.Amalgamator.owned && (game.resources.trimps.realMax() / game.resources.trimps.getCurrentSend()) > 2000))) continue;
         
         //WS
         if (upgrade == 'Coordination' && getEmpowerment() == "Wind" && 
-            ((getPageSetting('AutoStance') == 3 && game.global.challengeActive != "Daily" && getPageSetting('WindStackingMin') > 0 && game.global.world >= getPageSetting('WindStackingMin') && calcHDRatio() < 5) ||
-                (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily" && getPageSetting('dWindStackingMin') > 0 && game.global.world >= getPageSetting('dWindStackingMin') && calcHDRatio() < 5)))
+            ((getPageSetting('AutoStance') == 3 && game.global.challengeActive != "Daily" && getPageSetting('WindStackingMin') > 0 && game.global.world >= getPageSetting('WindStackingMin') && hdStats.hdRatio < 5) ||
+                (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily" && getPageSetting('dWindStackingMin') > 0 && game.global.world >= getPageSetting('dWindStackingMin') && hdStats.hdRatio < 5)))
                     continue;
         
         if (upgrade == 'Coordination' && 
-            ((getPageSetting('AutoStance') == 3 && game.global.challengeActive != "Daily" && getPageSetting('wsmax') > 0 && getPageSetting('wsmaxhd') > 0 && game.global.world >= getPageSetting('wsmax') && calcHDRatio() < getPageSetting('wsmaxhd')) ||
-                (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily" && getPageSetting('dwsmax') > 0 && getPageSetting('dwsmaxhd') > 0 && game.global.world >= getPageSetting('dwsmax') && calcHDRatio() < getPageSetting('dwsmaxhd'))))
+            ((getPageSetting('AutoStance') == 3 && game.global.challengeActive != "Daily" && getPageSetting('wsmax') > 0 && getPageSetting('wsmaxhd') > 0 && game.global.world >= getPageSetting('wsmax') && hdStats.hdRatio < getPageSetting('wsmaxhd')) ||
+                (getPageSetting('use3daily') == true && game.global.challengeActive == "Daily" && getPageSetting('dwsmax') > 0 && getPageSetting('dwsmaxhd') > 0 && game.global.world >= getPageSetting('dwsmax') && hdStats.hdRatio < getPageSetting('dwsmaxhd'))))
                     continue;
         
         //Gigastations


### PR DESCRIPTION
Move calculations for void maps, H/D ratio, and hits survived to a dedicated classes/methods, and pass them into functions where they're needed. This reduces the amount of global variables, and allows us to not repeat the same calculations multiple times.