### PR TITLE
Automapping: multiple improvements

### DIFF
--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -247,6 +247,20 @@ function countPrestigesInMap() {
     return (map ? addSpecials(true, true, map) : 0);
 }
 
+function mapLevelHasPrestiges(level) {
+    for (const eq of Object.values(equipmentList)) {
+        if (!eq.Equip) {
+            continue;
+        }
+        const prestigeUnlock = game.mapUnlocks[eq.Upgrade];
+        const pMapLevel = prestigeUnlock.last + 5;
+        if (game.upgrades[eq.Upgrade].allowed && prestigeUnlock && pMapLevel <= level) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function armorCapped() {
     var capped = areWeHealthLevelCapped();
 

--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -250,7 +250,7 @@ function countPrestigesInMap() {
 function armorCapped() {
     var capped = areWeHealthLevelCapped();
 
-    const prestigeList = ['Bootboost', 'Hellishmet', 'Pantastic', 'Smoldershoulder', 'Greatersword', 'GamesOP'];
+    const prestigeList = ['Bootboost', 'Hellishmet', 'Pantastic', 'Smoldershoulder', 'Greatersword', 'GambesOP'];
     var numUnbought = 0;
     for (var i = 0, len = prestigeList.length; i < len; i++) {
         var p = prestigeList[i];

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -565,8 +565,8 @@ class MapCrafter {
             // increase map level
             return true;
         }
-        // add map mod if we currently don't have one
-        return existingMap.bonus === undefined && this.getMod() !== undefined;
+        // add map mod if the current one is useless
+        return !this.profile.mods.includes(existingMap.bonus) && this.profile.mods.includes(this.getMod());
     }
 
     getDevDebugArgs() {

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -1183,7 +1183,7 @@ function autoMap(hdStats, vmStatus) {
     if (doMaxMapBonus) shouldDoMaps = true;
 
     const farming = (shouldFarm || shouldFarmDamage || !enoughHealth || preSpireFarming || (vmStatus.prepareForVoids && !enoughDamage));
-    const needMetal = (!enoughHealth || !enoughDamage);
+    const needMetal = (!enoughHealth && !armorCapped() || !enoughDamage && !weaponCapped());
 
     const mappingProfile = new MappingProfile(farming, needMetal, needPrestige, prestigeMapLevel, shouldFarmLowerZone);
     const runUniques = (getPageSetting('AutoMaps') === 1);


### PR DESCRIPTION
There are multiple independent commits, you can review them separately. Meaningful changes:
- Support "perfect sliders" checkbox when crafting
- Don't create "farming" versions of mapping profiles, reuse the farming profile instead (with an added note in the automap tooltip)
- Simplify some needlessly complex ifs when deciding whether to repeat a map or auto-abandon troops