### PR TITLE
Don't Update Borders/Color for Housing/Equipment when in Time Lapse 

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -166,11 +166,10 @@ function mainLoop() {
         const vmStatus = getVoidMapStatus();
         const hdStats = new HDStats(vmStatus);
 
-        //Offline Progress
-        if (!usingRealTimeOffline) { 
-            setScienceNeeded();
-            autoLevelEquipment(hdStats, vmStatus);
-        }
+
+        setScienceNeeded();
+        autoLevelEquipment(hdStats, vmStatus);
+
 
         //Core
         if (getPageSetting('AutoMaps') > 0) {

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1,6 +1,6 @@
 var ATversion = 'ZekRayDee v5.2';
 var atscript = document.getElementById('AutoTrimps-script');
-var basepath = 'https://raw.githack.com/KeinNiemand/AutoTrimpsRay/gh-pages/', modulepath='modules/';
+var basepath = 'https://Psycho-Ray.github.io/AutoTrimps/', modulepath='modules/';
 atscript !== null && (basepath = atscript.src.replace(/AutoTrimps2\.js$/,''));
 
 function ATscriptLoad(a,b) {

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1,6 +1,6 @@
 var ATversion = 'ZekRayDee v5.2';
 var atscript = document.getElementById('AutoTrimps-script');
-var basepath = 'https://Psycho-Ray.github.io/AutoTrimps/', modulepath='modules/';
+var basepath = 'https://raw.githack.com/KeinNiemand/AutoTrimpsRay/gh-pages/', modulepath='modules/';
 atscript !== null && (basepath = atscript.src.replace(/AutoTrimps2\.js$/,''));
 
 function ATscriptLoad(a,b) {

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -78,7 +78,7 @@ function buyFoodEfficientHousing() {
     var unlockedHousing = ["Hut", "House", "Mansion", "Hotel", "Resort"].filter(b => !game.buildings[b].locked);
 
     //Resets Border Color
-    unlockedHousing.forEach(b => document.getElementById(b).style.border = "1px solid #FFFFFF")
+    unlockedHousing.forEach(b => UpdateBorder(b))
 
     //Checks for Limits
     if (!ignoresLimit) {
@@ -88,7 +88,7 @@ function buyFoodEfficientHousing() {
                 return true;
 
             //But paints their border before removing them
-            document.getElementById(b).style.border = "1px solid orange"
+            UpdateBorder(b);
             return false
         })
     }
@@ -105,7 +105,7 @@ function buyFoodEfficientHousing() {
 
     //If Food Efficiency Ignores Limit is enabled, then it only buy Huts and Houses here
     if (!ignoresLimit || ["Hut", "House"].includes(bestFoodBuilding.name)) {
-        document.getElementById(bestFoodBuilding.name).style.border = "1px solid #00CC01";
+        UpdateBorder(bestFoodBuilding.name);
         safeBuyBuilding(bestFoodBuilding.name);
     }
 }
@@ -124,7 +124,7 @@ function buyGemEfficientHousing() {
         var cost = getBuildingItemPrice(building, "gems", false, 1);
         var ratio = cost / building.increase.by;
         obj[unlockedHousing[house]] = ratio;
-        document.getElementById(unlockedHousing[house]).style.border = "1px solid #FFFFFF";
+        UpdateBorder(unlockedHousing[house]);
     }
     var keysSorted = Object.keys(obj).sort(function (a, b) {
             return obj[a] - obj[b];
@@ -135,12 +135,12 @@ function buyGemEfficientHousing() {
         if (max === false) max = -1;
         if (game.buildings[keysSorted[best]].owned < max || max == -1 || (getPageSetting('GemEfficiencyIgnoresMax') && keysSorted[best] != "Gateway")) {
             bestGemBuilding = keysSorted[best];
-            document.getElementById(bestGemBuilding).style.border = "1px solid #00CC00";
+            UpdateBorder(bestGemBuilding);
 
             //Gateway Wall
             if (bestGemBuilding == "Gateway" && getPageSetting('GatewayWall') > 1) {
                 if (getBuildingItemPrice(game.buildings.Gateway, "fragments", false, 1) > (game.resources.fragments.owned / getPageSetting('GatewayWall'))) {
-                    document.getElementById(bestGemBuilding).style.border = "1px solid orange";
+                    UpdateBorder(bestGemBuilding);
                     bestGemBuilding = null;
                     continue;
                 }
@@ -362,7 +362,7 @@ function RbuyFoodEfficientHousing() {
             'name': unlockedHousing[house],
             'ratio': ratio
         });
-        document.getElementById(unlockedHousing[house]).style.border = "1px solid #FFFFFF";
+        UpdateBorder(unlockedHousing[house])
     }
     buildorder.sort(function (a, b) {
         return a.ratio - b.ratio;
@@ -374,7 +374,7 @@ function RbuyFoodEfficientHousing() {
         bestfoodBuilding = bb.name;
     }
     if (smithylogic(bestfoodBuilding, 'wood', false) && bestfoodBuilding) {
-        document.getElementById(bestfoodBuilding).style.border = "1px solid #00CC01";
+        UpdateBorder(bestfoodBuilding);
         RsafeBuyBuilding(bestfoodBuilding);
     }
     }
@@ -394,7 +394,7 @@ function RbuyGemEfficientHousing() {
         var cost = getBuildingItemPrice(building, "gems", false, 1);
         var ratio = cost / building.increase.by;
         obj[unlockedHousing[house]] = ratio;
-        document.getElementById(unlockedHousing[house]).style.border = "1px solid #FFFFFF";
+        UpdateBorder(unlockedHousing[house]);
     }
     var keysSorted = Object.keys(obj).sort(function (a, b) {
             return obj[a] - obj[b];
@@ -405,7 +405,7 @@ function RbuyGemEfficientHousing() {
         if (max === false) max = -1;
         if (game.buildings[keysSorted[best]].owned < max || max == -1) {
             bestBuilding = keysSorted[best];
-            document.getElementById(bestBuilding).style.border = "1px solid #00CC00";
+            UpdateBorder(bestBuilding);
             break;
         }
     }
@@ -532,4 +532,11 @@ function RbuyBuildings() {
 	}
     }
  
+}
+
+function UpdateBorder(b, value) {
+    if (!usingRealTimeOffline) {
+        document.getElementById(b).style.border = value;
+    }
+    
 }

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -535,7 +535,7 @@ function RbuyBuildings() {
 }
 
 function UpdateBorder(b, value) {
-    if (!useRealTimeOffline) {
+    if (!usingRealTimeOffline) {
         document.getElementById(b).style.border = value;
     }
     

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -78,7 +78,7 @@ function buyFoodEfficientHousing() {
     var unlockedHousing = ["Hut", "House", "Mansion", "Hotel", "Resort"].filter(b => !game.buildings[b].locked);
 
     //Resets Border Color
-    unlockedHousing.forEach(b => UpdateBorder(b))
+    unlockedHousing.forEach(b => UpdateBorder(b,  "1px solid #FFFFFF"))
 
     //Checks for Limits
     if (!ignoresLimit) {
@@ -88,7 +88,7 @@ function buyFoodEfficientHousing() {
                 return true;
 
             //But paints their border before removing them
-            UpdateBorder(b);
+            UpdateBorder(b,  "1px solid orange")
             return false
         })
     }
@@ -105,7 +105,7 @@ function buyFoodEfficientHousing() {
 
     //If Food Efficiency Ignores Limit is enabled, then it only buy Huts and Houses here
     if (!ignoresLimit || ["Hut", "House"].includes(bestFoodBuilding.name)) {
-        UpdateBorder(bestFoodBuilding.name);
+        UpdateBorder(bestFoodBuilding.name,  "1px solid #00CC01");
         safeBuyBuilding(bestFoodBuilding.name);
     }
 }
@@ -124,7 +124,7 @@ function buyGemEfficientHousing() {
         var cost = getBuildingItemPrice(building, "gems", false, 1);
         var ratio = cost / building.increase.by;
         obj[unlockedHousing[house]] = ratio;
-        UpdateBorder(unlockedHousing[house]);
+        UpdateBorder(unlockedHousing[house],  "1px solid #FFFFFF");
     }
     var keysSorted = Object.keys(obj).sort(function (a, b) {
             return obj[a] - obj[b];
@@ -135,12 +135,12 @@ function buyGemEfficientHousing() {
         if (max === false) max = -1;
         if (game.buildings[keysSorted[best]].owned < max || max == -1 || (getPageSetting('GemEfficiencyIgnoresMax') && keysSorted[best] != "Gateway")) {
             bestGemBuilding = keysSorted[best];
-            UpdateBorder(bestGemBuilding);
+            UpdateBorder(bestGemBuilding,  "1px solid #00CC00");
 
             //Gateway Wall
             if (bestGemBuilding == "Gateway" && getPageSetting('GatewayWall') > 1) {
                 if (getBuildingItemPrice(game.buildings.Gateway, "fragments", false, 1) > (game.resources.fragments.owned / getPageSetting('GatewayWall'))) {
-                    UpdateBorder(bestGemBuilding);
+                    UpdateBorder(bestGemBuilding,  "1px solid orange");
                     bestGemBuilding = null;
                     continue;
                 }
@@ -362,7 +362,7 @@ function RbuyFoodEfficientHousing() {
             'name': unlockedHousing[house],
             'ratio': ratio
         });
-        UpdateBorder(unlockedHousing[house])
+        UpdateBorder(unlockedHousing[house],  "1px solid #FFFFFF");
     }
     buildorder.sort(function (a, b) {
         return a.ratio - b.ratio;
@@ -374,7 +374,7 @@ function RbuyFoodEfficientHousing() {
         bestfoodBuilding = bb.name;
     }
     if (smithylogic(bestfoodBuilding, 'wood', false) && bestfoodBuilding) {
-        UpdateBorder(bestfoodBuilding);
+        UpdateBorder(bestfoodBuilding,  "1px solid #00CC01");
         RsafeBuyBuilding(bestfoodBuilding);
     }
     }
@@ -394,7 +394,7 @@ function RbuyGemEfficientHousing() {
         var cost = getBuildingItemPrice(building, "gems", false, 1);
         var ratio = cost / building.increase.by;
         obj[unlockedHousing[house]] = ratio;
-        UpdateBorder(unlockedHousing[house]);
+        UpdateBorder(unlockedHousing[house],  "1px solid #FFFFFF");
     }
     var keysSorted = Object.keys(obj).sort(function (a, b) {
             return obj[a] - obj[b];
@@ -405,7 +405,7 @@ function RbuyGemEfficientHousing() {
         if (max === false) max = -1;
         if (game.buildings[keysSorted[best]].owned < max || max == -1) {
             bestBuilding = keysSorted[best];
-            UpdateBorder(bestBuilding);
+            UpdateBorder(bestBuilding,  "1px solid #00CC00");
             break;
         }
     }
@@ -535,7 +535,7 @@ function RbuyBuildings() {
 }
 
 function UpdateBorder(b, value) {
-    if (!usingRealTimeOffline) {
+    if (!useRealTimeOffline) {
         document.getElementById(b).style.border = value;
     }
     

--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -332,7 +332,7 @@ function autoLevelEquipment(hdStats, vmStatus) {
         var gameResource = equip.Equip ? game.equipment[equipName] : game.buildings[equipName];
         if (!gameResource.locked) {
             var $equipName = document.getElementById(equipName);
-            $equipName.style.color = 'white';
+            UpdateEquipColor($equipName, 'white');
             var evaluation = evaluateEquipmentEfficiency(equipName);
             var BKey = equip.Stat + equip.Resource;
 
@@ -346,20 +346,20 @@ function autoLevelEquipment(hdStats, vmStatus) {
             resourcesNeeded[equip.Resource] += Best[BKey].Cost;
 
             if (evaluation.Wall)
-                $equipName.style.color = 'yellow';
-            $equipName.style.border = '1px solid ' + evaluation.StatusBorder;
+                UpdateEquipColor($equipName, 'yellow');
+            UpdateEquipBorder($equipName, '1px solid ' + evaluation.StatusBorder);
 
             var $equipUpgrade = document.getElementById(equip.Upgrade);
             if (evaluation.StatusBorder != 'white' && evaluation.StatusBorder != 'yellow' && $equipUpgrade)
-                $equipUpgrade.style.color = evaluation.StatusBorder;
+                UpdateEquipColor($equipUpgrade, evaluation.StatusBorder);
             if (evaluation.StatusBorder == 'yellow' && $equipUpgrade)
-                $equipUpgrade.style.color = 'white';
+                UpdateEquipColor($equipUpgrade, 'white');
             if (equipName == 'Gym' && needGymystic()) {
-                $equipName.style.color = 'white';
-                $equipName.style.border = '1px solid white';
+                UpdateEquipColor($equipName, 'white');
+                UpdateEquipBorder($equipName, '1px solid white');
                 if ($equipUpgrade) {
-                    $equipUpgrade.style.color = 'red';
-                    $equipUpgrade.style.border = '2px solid red';
+                    UpdateEquipColor($equipUpgrade, 'red');
+                    UpdateEquipBorder($equipUpgrade, '2px solid red');
                 }
             }
 
@@ -384,8 +384,8 @@ function autoLevelEquipment(hdStats, vmStatus) {
                         debug('Upgrading ' + upgrade + " # " + game.upgrades[upgrade].allowed, "equips", '*upload');
                     buyUpgrade(upgrade, true, true);
                 } else {
-                    $equipName.style.color = 'orange';
-                    $equipName.style.border = '2px solid orange';
+                    UpdateEquipColor($equipName, 'orange');
+                    UpdateEquipBorder($equipName, '2px solid orange');
                 }
             }
         }
@@ -400,12 +400,12 @@ function autoLevelEquipment(hdStats, vmStatus) {
             var $eqName = document.getElementById(eqName);
             var DaThing = equipmentList[eqName];
             if (eqName == 'Gym' && needGymystic()) {
-                $eqName.style.color = 'white';
-                $eqName.style.border = '1px solid white';
+                UpdateEquipColor($eqName, 'white');
+                UpdateEquipBorder($eqName,'1px solid white');
                 continue;
             } else {
-                $eqName.style.color = Best[stat].Wall ? 'orange' : 'red';
-                $eqName.style.border = '2px solid red';
+                UpdateEquipColor($eqName, Best[stat].Wall ? 'orange' : 'red');
+                UpdateEquipBorder($eqName,'2px solid red');
             }
             var maxmap = getPageSetting('MaxMapBonusAfterZone') && doMaxMapBonus;
             if (BuyArmorLevels && (DaThing.Stat == 'health' || DaThing.Stat == 'block') && (!enoughHealth || !enoughHealthE && enoughDamage || maxmap)) {
@@ -676,7 +676,7 @@ function RautoLevelEquipment() {
         var gameResource = game.equipment[equipName];
         if (!gameResource.locked) {
             var $equipName = document.getElementById(equipName);
-            $equipName.style.color = 'white';
+            UpdateEquipColor($equipName, 'white');
             var evaluation = RevaluateEquipmentEfficiency(equipName);
             var BKey = equip.Stat + equip.Resource;
 
@@ -690,14 +690,14 @@ function RautoLevelEquipment() {
             RresourcesNeeded[equip.Resource] += RBest[BKey].Cost;
 
             if (evaluation.Wall)
-                $equipName.style.color = 'yellow';
-            $equipName.style.border = '1px solid ' + evaluation.StatusBorder;
+                UpdateEquipColor($equipName, 'yellow');
+            UpdateEquipBorder($equipName, '1px solid ' + evaluation.StatusBorder);
 
             var $equipUpgrade = document.getElementById(equip.Upgrade);
             if (evaluation.StatusBorder != 'white' && evaluation.StatusBorder != 'yellow' && $equipUpgrade)
-                $equipUpgrade.style.color = evaluation.StatusBorder;
+                UpdateEquipColor($equipUpgrade, evaluation.StatusBorder);
             if (evaluation.StatusBorder == 'yellow' && $equipUpgrade)
-                $equipUpgrade.style.color = 'white';
+                UpdateEquipColor($equipUpgrade, 'white');
             if (evaluation.StatusBorder == 'red') {
                 var BuyWeaponUpgrades = ((getPageSetting('RBuyWeaponsNew') == 1) || (getPageSetting('RBuyWeaponsNew') == 2));
                 var BuyArmorUpgrades = ((getPageSetting('RBuyArmorNew') == 1) || (getPageSetting('RBuyArmorNew') == 2));
@@ -721,8 +721,8 @@ function RautoLevelEquipment() {
                     debug('Upgrading ' + upgrade + " - Prestige " + game.equipment[equipName].prestige, "equips", '*upload');
                     buyUpgrade(upgrade, true, true);
                 } else {
-                    $equipName.style.color = 'orange';
-                    $equipName.style.border = '2px solid orange';
+                    UpdateEquipColor($equipName, 'orange');
+                    UpdateEquipBorder($equipName, '2px solid orange');
                 }
             }
         }
@@ -736,8 +736,8 @@ function RautoLevelEquipment() {
         if (eqName !== '') {
             var $eqName = document.getElementById(eqName);
             var DaThing = RequipmentList[eqName];
-            $eqName.style.color = RBest[stat].Wall ? 'orange' : 'red';
-            $eqName.style.border = '2px solid red';
+            UpdateEquipColor($eqName, RBest[stat].Wall ? 'orange' : 'red');
+            UpdateEquipBorder($eqName,'2px solid red');
             var maxmap = getPageSetting('RMaxMapBonusAfterZone') && RdoMaxMapBonus;
             if (BuyArmorLevels && DaThing.Stat == 'health' && (!enoughHealthE || maxmap)) {
                 game.global.buyAmt = Rgearamounttobuy
@@ -1168,4 +1168,16 @@ function estimateEquipsForZone() {
 
     return [totalCost, bonusLevels, tempEqualityUse];
     
+}
+
+function UpdateEquipColor(equip, color) {
+    if (!usingRealTimeOffline) {
+        equip.style.color = color;
+    }
+}
+
+function UpdateEquipBorder(equip, border) {
+    if (!usingRealTimeOffline) {
+        equip.style.border = border;
+    }
 }


### PR DESCRIPTION
When you unlock a new type of housing (or maybe also equipment/upgrade), whhile in Time Lapse, the button does not exist, becouse the UI dosn't update in time lapse, this will cause errors.
To fix this this PR adds a check to not update Colors or Borders when in time lapse/catching up
fixes #27 


This PR now also enables buying equipment while offline there was a check to not do that before, it seems to work fine after inital sets so maybe the reason that check was there was because it tried to change borders/colors which is fixed in the PR.

